### PR TITLE
Usunięto błąd edycji danych dentysty.

### DIFF
--- a/app/models/dentist.php
+++ b/app/models/dentist.php
@@ -133,7 +133,7 @@ class Dentist
               SET first_name = :first_name, 
                   last_name = :last_name, 
                   email = :email,
-                  specialization = :specialization,
+                  specialization = :specialization
               WHERE dentist_id = :dentist_id";
 
         $stmt = $this->db->prepare($query);


### PR DESCRIPTION
Błędem był przecinek po słowie 'specialization'. Usunięto ten przecinek.